### PR TITLE
update for linux installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
             # Pack to zip for Windows
             7z a -tzip "${release_name}.zip" "./${release_name}/*"
           else
-          tar czvf "${release_name}.tar.gz" "$release_name"
+            tar czvf "${release_name}.tar.gz" -C "$release_name" .
           fi
           # Delete output directory
           rm -r "$release_name"

--- a/README.md
+++ b/README.md
@@ -1,44 +1,53 @@
 # dotignore
 
-`dotignore` is a CLI tool for generating .gitignore files. 
+`dotignore` is a CLI tool for generating .gitignore files.
 
-# Usage
+## Installation
 
-## Create .gitignore files
+### Linux
+
+```sh
+wget https://github.com/bariscanyilmaz/dotignore/releases/download/[version]/dotignore-[version]-linux-x64.tar.gz
+
+sudo mkdir -p /usr/local/dotignore && sudo tar -C /usr/local/dotignore -xzf dotignore-[version]-linux-x64.tar.gz
+
+export PATH=$PATH:/usr/local/dotignore
+```
+
+## Usage
+
+### Create .gitignore files
 
 Create your dotignore files with init verb
 
 ```bash
 dotignore init <template>
 ```
-![dotignore-init-value](https://user-images.githubusercontent.com/30300440/130862256-998b5e65-8f01-4e98-8e60-a729f30ff91e.gif)
 
-
-
+![dotignore-init-value](https://user-images.githubusercontent.com/30300440/130862256-998b5e65-8f01-4e98-8e60-a729f30ff91e.gif)  
 
 Also, init is defeault verb and you can omit it
 
 ```bash
 dotignore <template>
 ```
-![dotignore-value](https://user-images.githubusercontent.com/30300440/130862290-a9182421-0168-4d8e-a697-a7c5be2ac1a9.gif)
 
+![dotignore-value](https://user-images.githubusercontent.com/30300440/130862290-a9182421-0168-4d8e-a697-a7c5be2ac1a9.gif)  
 
-
-## List available .gitignore templates
+### List available .gitignore templates
 
 List your dotignore files with ls verb
 
 ```bash
 dotignore ls 
 ```
-![dotignore-ls](https://user-images.githubusercontent.com/30300440/130862328-38127d04-3aa1-45bd-a4d0-2117dc1fef18.gif)
 
-
+![dotignore-ls](https://user-images.githubusercontent.com/30300440/130862328-38127d04-3aa1-45bd-a4d0-2117dc1fef18.gif)  
 
 Also, ls has -q or --query option for searching your template
 
 ```bash
 dotignore ls -q <template>
 ```
+
 ![dotignore-ls-q](https://user-images.githubusercontent.com/30300440/130862991-42fe1177-9bff-41e6-b85b-138be7a412c9.gif)


### PR DESCRIPTION
The filing structure of the archive for Linux was as follows;
```
$release_name/
$release_name/dotignore
$release_name/dotignore.pdb
```
After updating release.yml:
```
./
./dotignore
./dotignore.pdb
```
Anymore someone doesn't need to give an extra argument to the `tar` command to ignore the `$release_name` directory which is in `$release_name.tar.gz` while extracting the archive files for installation on Linux. But, you need to make a new release or make a filing structure as I mentioned in the existing release for Linux installation to work correctly.

After all of these, a Linux user can reach `dotignore` in any path.